### PR TITLE
update the mailing list icon

### DIFF
--- a/_includes/social-networks-links.html
+++ b/_includes/social-networks-links.html
@@ -29,7 +29,7 @@
     <a href="{{ site.social-network-links.mailinglist }}" title="Join the mailing list">
       <span class="fa-stack fa-lg" aria-hidden="true">
         <i class="fas fa-circle fa-stack-2x"></i>
-        <i class="fas fa-telegram fa-stack-1x fa-inverse"></i>
+        <i class="fab fa-telegram fa-stack-1x fa-inverse"></i>
       </span>
       <span class="sr-only">Join the mailing list</span>
    </a>


### PR DESCRIPTION
I noticed that the icon for the mailing list was not showing up (currently set at the Telegram icon)--trying a fix here.