### PR TITLE
Updating Ali's postprint-pledge-for-linguists 

### DIFF
--- a/_posts/2022-06-06-postprint-pledge-for-linguists.md
+++ b/_posts/2022-06-06-postprint-pledge-for-linguists.md
@@ -16,11 +16,11 @@ Sharing the accepted version (also called the postprint) of your article online 
 2. Remember to include publication details on the first page (e.g., journal title, etc.) so that others can cite your paper properly.
 3. You are free to go for a repository of your choice. The recommended repositories are:
 
-<https://www.iris-database.org> linguistics repository (highly recommended) \
-<https://osf.io/preprints> generalist repository \
-<https://psyarxiv.com> more toward psychology \ 
-<https://edarxiv.org> more toward education \
-<http://socarxiv.org> more toward social sciences \
+<https://www.iris-database.or/g> linguistics repository (highly recommended) \
+<https://osf.io/preprints/> generalist repository \
+<https://psyarxiv.com/> more toward psychology \ 
+<https://edarxiv.org/> more toward education \
+<http://socarxiv.org/> more toward social sciences \
 
 #### What this Pledge is NOT asking you to do:
 1. This Pledge does not ask you to break any laws. Sharing postprints is within your rights (see details at the link below).

--- a/_posts/2022-06-06-postprint-pledge-for-linguists.md
+++ b/_posts/2022-06-06-postprint-pledge-for-linguists.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Postprint Pledge for Linguistics
-subtitle: Pledge to share a postprint of every article you publish
+subtitle: Pledge to share the “accepted version” of every article you publish
 gh-repo: freeourknowledge/website
 cover-img: /assets/img/handcuffs.jpg
 thumbnail-img: /assets/img/green_oa_small.png
@@ -9,102 +9,32 @@ share-img: /assets/img/green_oa_small.png
 comments: true
 ---
 
-Accessibility of scientific research is a cornerstone of an equitable and fair academy. Paywalls have become a major obstacle that disadvantages many researchers in the Global South, preventing them from keeping up with the latest scholarship, let alone contributing to it.
+Sharing the accepted version (also called the postprint) of your article online does not violate the copyright policies of most publishers. At the same time, this simple move is an effective way to counteract paywalls and make science accessible to everyone in the world with an internet connection including researchers in the Global South—thus helping create an equitable and fair academy. 
 
-This does not have to be the case. According to most publishers’ copyright policies, authors are legally permitted to share the accepted version (the “postprint”) of their manuscripts online. **While the preprint is the paper that has not gone through peer review yet, the postprint is the version that has been <ins>accepted</ins> for publication but has not been copyedited by the publisher**. It is basically the final, pre-formatted draft that you submit to the journal to be published. Posting this postprint on your personal website or on a nonprofit repository does not violate the copyright requirements of most publishers (see table below).
-
-By taking this pledge, you undertake to make scholarship accessible to readers who may not have institutional subscriptions by making available the postprints of all articles you publish in the following applied linguistics journals (they give you the right to do so), either on your personal website or on a public repository.
- 
-#### What this Pledge is NOT asking you to do 
-1. This Pledge does not ask you to break any laws. Sharing postprints is within your rights (see details in the table).
-2. This Pledge does not ask you to share “preprints” (i.e., your manuscript before it was accepted), but to share the “postprint” (the accepted version before it is formatted and copyedited by the publisher). Simply put, you convert the final word document into pdf and share it. See example [here](https://psyarxiv.com/ugt9s/). (It is your choice if you also want to share your preprints.)
-3. This Pledge does not limit you to publishing in these journals.
-4. This Pledge does not require you do anything else (like boycotting certain publishers or not reviewing for them).
-
-#### What this Pledge ASKS you to do 
-1. Whenever you publish in these journals, share the postprint of your accepted manuscript online, either on your personal website and/or a public repository. (This assumes that your article will be behind a paywall and not already open access, of course.)
+#### What this Pledge ASKS you to do:
+1. Whenever you publish in these journals, share the postprint of your accepted manuscript online, either on your personal website and/or a public repository (if it is not already open access). 
 2. Remember to include publication details on the first page (e.g., journal title, etc.) so that others can cite your paper properly.
 3. You are free to go for a repository of your choice. The recommended repositories are:
 
-<http://osf.io/preprints> generalist repository \
-<http://psyarxiv.org/> more toward linguistics \
-<http://socarxiv.org/> more toward education 
+<https://www.iris-database.org> linguistics repository (highly recommended) \
+<https://osf.io/preprints> generalist repository
+<https://psyarxiv.com/> more toward psychology
+<https://edarxiv.org/> more toward education
+<http://socarxiv.org/> more toward social sciences
 
-After posting your postprint, you are welcome to announce it with the hashtag **#PostprintPledge** at the Facebook group [Applied Linguistics Research Methods--Discussion](https://www.facebook.com/groups/appliedlinguisticsresearchmethods/). **Don't wait** until you publish a new paper; pick a paper you have already published and share it now! 
+
+#### What this Pledge is NOT asking you to do:
+1. This Pledge does not ask you to break any laws. Sharing postprints is within your rights (see details at the link below).
+2. This Pledge does not ask you to share “preprints” (i.e., your manuscript before it was accepted), but to share the “postprint” (the accepted version before it is formatted and copyedited by the publisher). It is your choice if you also want to share your preprints.
+3. This Pledge does not limit you to publishing in journals listed in this Pledge (see the link below).
+4. This Pledge does not require you do anything else (like boycotting certain publishers or not reviewing for them).
 
 #### Who can sign? 
-This campaign is open to researchers in Applied Linguistics and Second Language Acquisition, but all researchers in Linguistics are welcome. We compiled a list of journals in Applied Linguistics and Second Language Acquisition, each with its copyright policies to make things clearer for potential Pledgers. We invite advocates from other fields to do the same. 
+This campaign is open to researchers in Applied Linguistics and Second Language Acquisition, but all researchers in Linguistics are welcome. We compiled a list of journals in Applied Linguistics and Second Language Acquisition, each with its copyright policies to make things clearer for potential Pledgers. We invite advocates from other fields to do the same.
 
 #### When will my pledge activate? 
-Your pledge will activate as soon as you sign it, meaning that you should share your postprints immediately. You are also invited to share postprints of your previously published papers if they are behind paywalls. 
+Your pledge will activate as soon as you sign it, meaning that you should share your postprints immediately. You are also invited to share postprints of your previously published papers if they are behind paywalls.
 
-#### Who has taken the pledge? 
-<iframe width='100%' height='470' src="https://docs.google.com/spreadsheets/d/e/2PACX-1vQSxwa1ADHwzqmEAWzoUZluMTLunZnYbztIbtUi4FWl4ar-eb85Yx-UYXwUWbi-R6EAe5-55q7AYrAC/pubhtml?gid=584199642&amp;single=true&amp;widget=true&amp;headers=false"></iframe>
+To sign up, please visit this page: 
+https://www.ali-alhoorie.com/postprint-pledge
 
-#### Take the pledge! 
-<iframe src="https://docs.google.com/forms/d/e/1FAIpQLSfLCySIEk3EVaZkqd0YPbwMpPhmsrgBhubuft8OD9PqVeQ-ng/viewform?embedded=true" width="640" height="600" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
-
-#### Linguistics Journals Policies 
-
-|           |     Journal                                                               |     Publisher                    |     Personal   Website    |     Repository       |     More   Info                                        |
-|-----------|---------------------------------------------------------------------------|----------------------------------|---------------------------|----------------------|--------------------------------------------------------|
-|     1     |     Annual Review of Applied   Linguistics                                |     Cambridge                    |     Yes                   |     Yes              |     https://v2.sherpa.ac.uk/id/publication/1411        |
-|     2     |     Applied Psycholinguistics                                             |     Cambridge                    |     Yes                   |     Yes              |     https://v2.sherpa.ac.uk/id/publication/1413        |
-|     3     |     Bilingualism-Language and Cognition                                   |     Cambridge                    |     Yes                   |     Yes              |     https://v2.sherpa.ac.uk/id/publication/1556        |
-|     4     |     Journal of French Language Studies                                    |     Cambridge                    |     Yes                   |     Yes              |     https://v2.sherpa.ac.uk/id/publication/1707        |
-|     5     |     Language in Society                                                   |     Cambridge                    |     Yes                   |     Yes              |     https://v2.sherpa.ac.uk/id/publication/2080        |
-|     6     |     Language Teaching                                                     |     Cambridge                    |     Yes                   |     Yes              |     https://v2.sherpa.ac.uk/id/publication/2081        |
-|     7     |     RECALL                                                                |     Cambridge                    |     Yes                   |     Yes              |     https://v2.sherpa.ac.uk/id/publication/2177        |
-|     8     |     Studies in Second Language   Acquisition                              |     Cambridge                    |     Yes                   |     Yes              |     https://v2.sherpa.ac.uk/id/publication/2195        |
-|     9     |     Language and Cognition                                                |     De Gruyter                   |     Yes                   |     Yes              |     https://v2.sherpa.ac.uk/id/publication/3297        |
-|     10    |     Journal of Second Language Writing                                    |     Elsevier                     |     Yes                   |     Yes              |     https://v2.sherpa.ac.uk/id/publication/14112       |
-|     11    |     Assessing Writing                                                     |     Elsevier                     |     Yes                   |     Yes              |     https://v2.sherpa.ac.uk/id/publication/16729       |
-|     12    |     English for Specific Purposes                                         |     Elsevier                     |     Yes                   |     Yes              |     https://v2.sherpa.ac.uk/id/publication/16893       |
-|     13    |     Journal of English for Academic   Purposes                            |     Elsevier                     |     Yes                   |     Yes              |     https://v2.sherpa.ac.uk/id/publication/13884       |
-|     14    |     Journal of Memory and Language                                        |     Elsevier                     |     Yes                   |     Yes              |     https://v2.sherpa.ac.uk/id/publication/14005       |
-|     15    |     Journal of Neurolinguistics                                           |     Elsevier                     |     Yes                   |     Yes              |     https://v2.sherpa.ac.uk/id/publication/14023       |
-|     16    |     Language & Communication                                              |     Elsevier                     |     Yes                   |     Yes              |     https://v2.sherpa.ac.uk/id/publication/16711       |
-|     17    |     Language Sciences                                                     |     Elsevier                     |     Yes                   |     Yes              |     https://v2.sherpa.ac.uk/id/publication/16950       |
-|     18    |     Linguistics And Education                                             |     Elsevier                     |     Yes                   |     Yes              |     https://v2.sherpa.ac.uk/id/publication/16713       |
-|     19    |     System                                                                |     Elsevier                     |     Yes                   |     Yes              |     https://v2.sherpa.ac.uk/id/publication/16930       |
-|     20    |     International Journal of Corpus   Linguistics                         |     John   Benjamins             |     Yes                   |     Yes              |     https://v2.sherpa.ac.uk/id/publication/10956       |
-|     21    |     Language Problems & Language   Planning                               |     John   Benjamins             |     Yes                   |     Yes              |     https://v2.sherpa.ac.uk/id/publication/10973       |
-|     22    |     Narrative Inquiry                                                     |     John   Benjamins             |     Yes                   |     Yes              |     https://v2.sherpa.ac.uk/id/publication/10983       |
-|     23    |     Review of Cognitive Linguistics                                       |     John   Benjamins             |     Yes                   |     Yes              |     https://v2.sherpa.ac.uk/id/publication/10987       |
-|     24    |     Spanish in Context                                                    |     John   Benjamins             |     Yes                   |     Yes              |     https://v2.sherpa.ac.uk/id/publication/10991       |
-|     25    |     International Journal of Bilingualism                                 |     Sage                         |     Yes                   |     Yes              |     https://v2.sherpa.ac.uk/id/publication/9206        |
-|     26    |     Journal of Language and Social    Psychology                          |     Sage                         |     Yes                   |     Yes              |     https://v2.sherpa.ac.uk/id/publication/9305        |
-|     27    |     Language Teaching Research                                            |     Sage                         |     Yes                   |     Yes              |     https://v2.sherpa.ac.uk/id/publication/9366        |
-|     28    |     Language Testing                                                      |     Sage                         |     Yes                   |     Yes              |     https://v2.sherpa.ac.uk/id/publication/9367        |
-|     29    |     RELC Journal                                                          |     Sage                         |     Yes                   |     Yes              |     https://v2.sherpa.ac.uk/id/publication/9447        |
-|     30    |     Second Language Research                                              |     Sage                         |     Yes                   |     Yes              |     https://v2.sherpa.ac.uk/id/publication/9464        |
-|     31    |     Across Languages and Cultures                                         |     Akadémiai   Kiadó            |     Yes                   |     Yes              |     https://v2.sherpa.ac.uk/id/publication/2110        |
-|     32    |     English Teaching-Practice and Critique                                |     Emerald                      |     Yes                   |     Yes              |     https://v2.sherpa.ac.uk/id/publication/32354       |
-|     33    |     Language Cognition and   Neuroscience                                 |     Taylor   & Francis           |     Yes                   |     Yes              |     https://v2.sherpa.ac.uk/id/publication/39268       |
-|     34    |     Journal of Psycholinguistic   Research                                |     Springer                     |     Yes                   |     12m   embargo    |     https://v2.sherpa.ac.uk/id/publication/15732       |
-|     35    |     Language Learning and Development                                     |     Springer                     |     Yes                   |     12m   embargo    |     https://v2.sherpa.ac.uk/id/publication/14046       |
-|     36    |     Language Policy                                                       |     Springer                     |     Yes                   |     12m   embargo    |     https://v2.sherpa.ac.uk/id/publication/17226       |
-|     37    |     Computer Assisted Language   Learning                                 |     Taylor   & Francis           |     Yes                   |     18m   embargo    |     https://v2.sherpa.ac.uk/id/publication/5093        |
-|     38    |     Current Issues in Language   Planning                                 |     Taylor   & Francis           |     Yes                   |     18m   embargo    |     https://v2.sherpa.ac.uk/id/publication/19858       |
-|     39    |     International Journal of Bilingual   Education And    Bilingualism    |     Taylor   & Francis           |     Yes                   |     18m   embargo    |     https://v2.sherpa.ac.uk/id/publication/19862       |
-|     40    |     International Journal of   Multilingualism                            |     Taylor   & Francis           |     Yes                   |     18m   embargo    |     https://v2.sherpa.ac.uk/id/publication/19863       |
-|     41    |     International Multilingual   Research Journal                         |     Taylor   & Francis           |     Yes                   |     18m   embargo    |     https://v2.sherpa.ac.uk/id/publication/5454        |
-|     42    |     Journal of Language Identity and   Education                          |     Taylor   & Francis           |     Yes                   |     18m   embargo    |     https://v2.sherpa.ac.uk/id/publication/5648        |
-|     43    |     Journal of Multilingual And    Multicultural Development              |     Taylor   & Francis           |     Yes                   |     18m   embargo    |     https://v2.sherpa.ac.uk/id/publication/25423       |
-|     44    |     Journal of Quantitative Linguistics                                   |     Taylor   & Francis           |     Yes                   |     18m   embargo    |     https://v2.sherpa.ac.uk/id/publication/5724        |
-|     45    |     Language and Education                                                |     Taylor   & Francis           |     Yes                   |     18m   embargo    |     https://v2.sherpa.ac.uk/id/publication/19873       |
-|     46    |     Language and Intercultural   Communication                            |     Taylor   & Francis           |     Yes                   |     18m   embargo    |     https://v2.sherpa.ac.uk/id/publication/19874       |
-|     47    |     Language Assessment Quarterly                                         |     Taylor   & Francis           |     Yes                   |     18m   embargo    |     https://v2.sherpa.ac.uk/id/publication/5805        |
-|     48    |     Language Awareness                                                    |     Taylor   & Francis           |     Yes                   |     18m   embargo    |     https://v2.sherpa.ac.uk/id/publication/5805        |
-|     49    |     Language Culture and Curriculum                                       |     Taylor   & Francis           |     Yes                   |     18m   embargo    |     https://v2.sherpa.ac.uk/id/publication/19876       |
-|     50    |     Language Matters                                                      |     Taylor   & Francis           |     Yes                   |     18m   embargo    |     https://v2.sherpa.ac.uk/id/publication/5808        |
-|     51    |     Research on Language and Social Interaction                           |     Taylor   & Francis           |     Yes                   |     18m   embargo    |     https://v2.sherpa.ac.uk/id/publication/6016        |
-|     52    |     Southern African Linguistics and   Applied Language    Studies        |     Taylor   & Francis           |     Yes                   |     18m   embargo    |     https://v2.sherpa.ac.uk/id/publication/295         |
-|     53    |     Applied Linguistics                                                   |     Oxford   University Press    |     Yes                   |     24m   embargo    |     https://v2.sherpa.ac.uk/id/publication/239         |
-|     54    |     ELT Journal                                                           |     Oxford   University Press    |     Yes                   |     24m   embargo    |     https://v2.sherpa.ac.uk/id/publication/419         |
-|     55    |     Language Learning                                                     |     Wiley                        |     12m embargo           |     12m embargo      |     https://v2.sherpa.ac.uk/id/publication/15998       |
-|     56    |     Foreign Language Annals                                               |     Wiley                        |     24m embargo           |     24m embargo      |     https://v2.sherpa.ac.uk/id/publication/13943       |
-|     57    |     International Journal of Applied   Linguistics                        |     Wiley                        |     24m embargo           |     24m embargo      |     https://v2.sherpa.ac.uk/id/publication/7018        |
-|     58    |     Modern Language Journal                                               |     Wiley                        |     24m embargo           |     24m embargo      |     https://v2.sherpa.ac.uk/id/publication/15814       |
-|     59    |     TESOL Quarterly                                                       |     Wiley                        |     24m embargo           |     24m embargo      |     https://v2.sherpa.ac.uk/id/publication/22134       |
-|     60    |     Mind & Language                                                       |     Wiley                        |     24m embargo           |     24m embargo      |     https://v2.sherpa.ac.uk/id/publication/7103        |

--- a/_posts/2022-06-06-postprint-pledge-for-linguists.md
+++ b/_posts/2022-06-06-postprint-pledge-for-linguists.md
@@ -16,14 +16,10 @@ Sharing the accepted version (also called the postprint) of your article online 
 2. Remember to include publication details on the first page (e.g., journal title, etc.) so that others can cite your paper properly.
 3. You are free to go for a repository of your choice. The recommended repositories are:
 
-<https://www.iris-database.org> linguistics repository (highly recommended) 
-
-<https://osf.io/preprints> generalist repository 
-
-<https://psyarxiv.com> more toward psychology  
-
-<https://edarxiv.org> more toward education 
-
+<https://www.iris-database.org> linguistics repository (highly recommended) \
+<https://osf.io/preprints> generalist repository \
+<https://psyarxiv.com> more toward psychology \
+<https://edarxiv.org> more toward education \
 <http://socarxiv.org> more toward social sciences 
 
 #### What this Pledge is NOT asking you to do:

--- a/_posts/2022-06-06-postprint-pledge-for-linguists.md
+++ b/_posts/2022-06-06-postprint-pledge-for-linguists.md
@@ -18,9 +18,9 @@ Sharing the accepted version (also called the postprint) of your article online 
 
 <https://www.iris-database.org> linguistics repository (highly recommended) \
 <https://osf.io/preprints> generalist repository \
-<https://psyarxiv.com/> more toward psychology \ 
-<https://edarxiv.org/> more toward education \
-<http://socarxiv.org/> more toward social sciences \
+<https://psyarxiv.com> more toward psychology \ 
+<https://edarxiv.org> more toward education \
+<http://socarxiv.org> more toward social sciences \
 
 #### What this Pledge is NOT asking you to do:
 1. This Pledge does not ask you to break any laws. Sharing postprints is within your rights (see details at the link below).

--- a/_posts/2022-06-06-postprint-pledge-for-linguists.md
+++ b/_posts/2022-06-06-postprint-pledge-for-linguists.md
@@ -17,11 +17,10 @@ Sharing the accepted version (also called the postprint) of your article online 
 3. You are free to go for a repository of your choice. The recommended repositories are:
 
 <https://www.iris-database.org> linguistics repository (highly recommended) \
-<https://osf.io/preprints> generalist repository
-<https://psyarxiv.com/> more toward psychology
-<https://edarxiv.org/> more toward education
-<http://socarxiv.org/> more toward social sciences
-
+<https://osf.io/preprints> generalist repository \
+<https://psyarxiv.com/> more toward psychology \ 
+<https://edarxiv.org/> more toward education \
+<http://socarxiv.org/> more toward social sciences \
 
 #### What this Pledge is NOT asking you to do:
 1. This Pledge does not ask you to break any laws. Sharing postprints is within your rights (see details at the link below).

--- a/_posts/2022-06-06-postprint-pledge-for-linguists.md
+++ b/_posts/2022-06-06-postprint-pledge-for-linguists.md
@@ -17,9 +17,13 @@ Sharing the accepted version (also called the postprint) of your article online 
 3. You are free to go for a repository of your choice. The recommended repositories are:
 
 <https://www.iris-database.or/g> linguistics repository (highly recommended) \
+
 <https://osf.io/preprints/> generalist repository \
+
 <https://psyarxiv.com/> more toward psychology \ 
+
 <https://edarxiv.org/> more toward education \
+
 <http://socarxiv.org/> more toward social sciences \
 
 #### What this Pledge is NOT asking you to do:

--- a/_posts/2022-06-06-postprint-pledge-for-linguists.md
+++ b/_posts/2022-06-06-postprint-pledge-for-linguists.md
@@ -16,15 +16,15 @@ Sharing the accepted version (also called the postprint) of your article online 
 2. Remember to include publication details on the first page (e.g., journal title, etc.) so that others can cite your paper properly.
 3. You are free to go for a repository of your choice. The recommended repositories are:
 
-<https://www.iris-database.or/g> linguistics repository (highly recommended) \
+<https://www.iris-database.org> linguistics repository (highly recommended) 
 
-<https://osf.io/preprints/> generalist repository \
+<https://osf.io/preprints> generalist repository 
 
-<https://psyarxiv.com/> more toward psychology \ 
+<https://psyarxiv.com> more toward psychology  
 
-<https://edarxiv.org/> more toward education \
+<https://edarxiv.org> more toward education 
 
-<http://socarxiv.org/> more toward social sciences \
+<http://socarxiv.org> more toward social sciences 
 
 #### What this Pledge is NOT asking you to do:
 1. This Pledge does not ask you to break any laws. Sharing postprints is within your rights (see details at the link below).


### PR DESCRIPTION
Updating Ali H. Al-Hoorie's postprint-pledge-for-linguists in accordance with his re-edit of the pledge. 
This PR consists of changes to a markdown file that word the pledge terms more concisely. 
Ali has looked at the edited version of 2022-06-06-postprint-pledge-for-linguists.md, and he agrees that the PR version matches his intentions.